### PR TITLE
페이지 타입 지정 논리 개선

### DIFF
--- a/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
@@ -42,6 +42,11 @@ namespace Xamarin.Forms.HotReload
 
         public void InitializeElement<TXaml>(TXaml element) where TXaml : Element
         {
+            InitializeElement(element, typeof(TXaml));
+        }
+
+        public void InitializeElement(Element element, Type elementType)
+        {
             if(!IsRunning)
             {
                 return;
@@ -49,8 +54,7 @@ namespace Xamarin.Forms.HotReload
 
             element.PropertyChanged += OnElementPropertyChanged;
 
-            var classType = typeof(TXaml);
-            var className = RetriveClassName(classType);
+            var className = RetriveClassName(elementType);
             if(!_fileMapping.TryGetValue(className, out ReloadItem item))
             {
                 item = new ReloadItem();
@@ -61,7 +65,7 @@ namespace Xamarin.Forms.HotReload
 
             if (string.IsNullOrWhiteSpace(item.Xaml))
             {
-                element.LoadFromXaml(classType);
+                element.LoadFromXaml(elementType);
                 _fileMapping[className] = item;
                 return;
             }


### PR DESCRIPTION
# 페이지 타입 지정 논리 개선
각 Xamarin.Forms Element 를 대상으로 HotReloader 를 설정 할 때 코드를 더 간편하게 작성할 수 있도록 Element 타입 지정 논리와 API 를 수정합니다.

## 유즈케이스

[README.md](https://github.com/AndreiMisiukevich/HotReload/blob/a3880c5c4b44c7a7a3ce23feb539682ae0585418/README.md) 에 설명된 바에 따르면, 기본적으로 HotReloader 를 초기화 하기 위해 모든 XAML Partial Class (ContentPage, ViewCell 등)는 다음과 같이 설정해야됩니다.

```csharp
#if DEBUG
using Xamarin.Forms.HotReload.Reloader;
#endif

using System.Windows.Input;

namespace Xamarin.Forms.HotReload.Sample
{
    public partial class MainPage : ContentPage
    {
        public MainPage()
        {
#if DEBUG
            this.InitializeElement();
#else
            InitializeComponent();
#endif
        }
    }
}
```

하지만 저는 HotReloader 설정 코드-`InitializeComponent`-를 반복해서 작성하기 싫었습니다([DRY-Don't Repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)). 대신에 저는 Page Factory 를 사용해서 Page 를 생성 할 때 HotRenderer 설정 코드도 함께 실행되게 하고 싶었습니다. 이렇게 하면 HotReloader 관련 코드가 한 곳으로 모이게 됩니다. 즉 Page 클래스는 모두 HotReloader 로 부터 격리되어 깨끗하게 코드를 유지할 수 있게 됩니다! 따라서 HotReloader 관련 코드 추가/삭제에 따른 영향이 미치는 범위가 작아지고, 추가/삭제 작업에서 느껴지는 불안감이 작아집니다. 당연하게도 작업 난이도 또한 쉬워집니다. 다음 두 개의 코드를 통해 구체적인 유즈케이스를 살펴봅시다.

- PageFactory 에 설정하는 방법
    ```csharp
    public class PageFactory : IPageFactory
    {
        
        // ...

        public TPage Create<TPage>() where TPage : Xamarin.Forms.Page
        {
            TPage page = _container.Resolve<TPage>();
    #if UseHotReload
            Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<TPage>(page);
    #endif
            return page;
        }

        // ...

    }
    ```

- [Prism Framework](https://github.com/PrismLibrary/Prism) 를 사용하는 경우, [PageNavigationService](https://github.com/PrismLibrary/Prism/blob/930e2b062eba7dcf38fc4aed603376ff06f15f44/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs) 를 커스텀하는 방법. 다음과 같이 Prism Framework의 INavigationService 만 커스텀하면 모든 Page 에 자동으로 HotReloader가 설정됨.

    ```csharp
    public class PageFactoryNavigationService : PageNavigationService
    {

        // ...
        
        protected override Page CreatePage(string segmentName)
        {
            Page page = base.CreatePage(segmentName);
    #if UseHotReload
            // 기존 API
            // Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<Page>(page);

            // 새로 추가된 API
            Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page, page.GetType());
    #endif
            return page;
        }
        
        // ...
    
    }
    ```

## 기존 코드 문제점

두 번째 유즈케이스에서 HotReloader 를 설정 할 때, 다음과 같이 기존 `InitializeElement` 메서드를 호출하면 문제가 발생합니다:

```csharp
// 기존 API
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<Page>(page);
```

이 경우 TXaml Generic Type 은 Xamarin.Forms.Page 타입인데, `InitializeElement<TXaml>(TXaml element)` 메서드가 내부적으로 **TXaml**  를 사용해서 page 인스턴스의 타입을 유추하는게 문제 원인입니다.

## 해결책

`InitializeElement` 메서드를 호출 할 때 호출자가 타입을 지정할 수 있게 메서드를 수정합니다. 동시에 기존 API 는 유용하기 때문에 그대로 지원하는 것을 고려합니다. 결과적으로 HotReloader 초기화 API 소비자는 다음 두 개의 API 를 사용할 수 있게 됩니다.

```csharp
// 기존 API
// void InitializeElement<TXaml>(TXaml element) where TXaml : Element
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page);

// 신규 추가 API
// void InitializeElement(Element element, Type elementType)
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page, page.GetType());
```

https://github.com/wplong11/HotReload/blob/a4b43869a96391d32d8fdf53de0971cd48ab975f/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs#L43-L74

## 폐기된 해결책

기존 `InitializeElement` 메서드가 TXaml 제네릭 타입을 사용하는 대신 element 인스턴스의 타입을 사용하도록 수정합니다. 이를 위해 아래 코드의 52번째 라인을 `var classType = element.GetType();` 으로 수정합니다.

https://github.com/wplong11/HotReload/blob/a3880c5c4b44c7a7a3ce23feb539682ae0585418/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs#L43-L70

이 해결책을 폐기한 이유는 기존 API 방식이 제공하는 유즈케이스를 더 이상 지원할 수 없기 때문입니다. 전달인자로 넘겨준 element 에 걸맞는 타입을 API 소비자가 직접 지정 할 수 있는 것은 유용하기 때문에 기존 유즈케이스를 지원해야됩니다.